### PR TITLE
非同期通信機能の追加

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,8 @@
+$(function() {
+
+  $(".form__box").submit(function() {
+    var inputs = $(".message__form").val();
+    console.log(inputs)
+  })
+
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -32,8 +32,8 @@ $(function() {
         .done(function(data){
           var html = buildHTML(data);
           setTimeout(function() {
-            $('.message__item').append(html)
-            $('.message__form').val('')
+            $('.message__item').append(html);
+            $('#new_message')[0].reset();
             $('.main__messages').animate({scrollTop: $('.main__messages')[0].scrollHeight}, 'fast');
             interceptFlag == 0;
           }, 500);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,17 @@
 $(function() {
 
+  function buildHTML(message) {
+    var image = ""
+    message.image ? image = `<img src="${message.image}">` : image = ""
+    var html = `<div class="message-sender">${message.name}</div>
+              <div class="message-date">${message.time}</div>
+              <div class="message-text">
+                <p>${message.text}</p>
+                ${image}
+              </div>`
+    return html;
+  }
+
   $(".form__box").submit(function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -11,6 +23,11 @@ $(function() {
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.message__item').append(html)
+      $('input__box').val('')
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -17,23 +17,31 @@ $(function() {
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action')
+    var interceptFlag = 0;
     $('.send__btn').removeAttr('data-disable-with');
-    $.ajax({
-      type: 'POST',
-      url: url,
-      data: formData,
-      dataType: 'json',
-      processData: false,
-      contentType: false
-    })
-    .done(function(data){
-      var html = buildHTML(data);
-      $('.message__item').append(html)
-      $('.message__form').val('')
-      $('.main__messages').animate({scrollTop: $('.main__messages')[0].scrollHeight}, 'fast');
-    })
-    .fail(function() {
-      alert('投稿できませんでした')
-    });
+      if(interceptFlag == 0){
+        interceptFlag == 1;
+        $.ajax({
+          type: 'POST',
+          url: url,
+          data: formData,
+          dataType: 'json',
+          processData: false,
+          contentType: false
+        })
+        .done(function(data){
+          var html = buildHTML(data);
+          setTimeout(function() {
+            $('.message__item').append(html)
+            $('.message__form').val('')
+            $('.main__messages').animate({scrollTop: $('.main__messages')[0].scrollHeight}, 'fast');
+            interceptFlag == 0;
+          }, 500);
+        })
+        .fail(function() {
+          alert('投稿できませんでした')
+          interceptFlag == 0;
+        });
+      }
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,16 @@
 $(function() {
 
-  $(".form__box").submit(function() {
-    var inputs = $(".message__form").val();
-    console.log(inputs)
+  $(".form__box").submit(function(e) {
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      type: 'POST',
+      url: url,
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
   })
-
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,21 +1,23 @@
 $(function() {
 
+  
   function buildHTML(message) {
     var image = ""
     message.image ? image = `<img src="${message.image}">` : image = ""
     var html = `<div class="message-sender">${message.name}</div>
-              <div class="message-date">${message.time}</div>
-              <div class="message-text">
-                <p>${message.text}</p>
-                ${image}
-              </div>`
+    <div class="message-date">${message.time}</div>
+    <div class="message-text">
+    <p>${message.text}</p>
+    ${image}
+    </div>`
     return html;
   }
-
-  $(".form__box").submit(function(e) {
+  
+  $('.form__box').submit(function(e) {
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action')
+    $('.send__btn').removeAttr('data-disable-with');
     $.ajax({
       type: 'POST',
       url: url,
@@ -27,7 +29,11 @@ $(function() {
     .done(function(data){
       var html = buildHTML(data);
       $('.message__item').append(html)
-      $('input__box').val('')
+      $('.message__form').val('')
+      $('.main__messages').animate({scrollTop: $('.main__messages')[0].scrollHeight}, 'fast');
     })
+    .fail(function() {
+      alert('投稿できませんでした')
+    });
   })
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,15 +7,19 @@ class MessagesController < ApplicationController
   end
 
   def create
-    binding.pry
-    @message = @room.messages.new(message_params)
-    if @message.save
-      redirect_to room_messages_path(@room), notice: 'メッセージが送信されました'
-    else
-      @messages = @room.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力してください'
-      render :index
-    end 
+    @message = @room.messages.create(message_params)
+    respond_to do |format|
+      format.html {redirect_to room_messages_path(@room)}
+      format.json
+    end
+
+    # if @message.save
+    #   redirect_to room_messages_path(@room), notice: 'メッセージが送信されました'
+    # else
+    #   @messages = @room.messages.includes(:user)
+    #   flash.now[:alert] = 'メッセージを入力してください'
+    #   render :index
+    # end 
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,14 +12,6 @@ class MessagesController < ApplicationController
       format.html {redirect_to room_messages_path(@room)}
       format.json
     end
-
-    # if @message.save
-    #   redirect_to room_messages_path(@room), notice: 'メッセージが送信されました'
-    # else
-    #   @messages = @room.messages.includes(:user)
-    #   flash.now[:alert] = 'メッセージを入力してください'
-    #   render :index
-    # end 
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,6 +7,7 @@ class MessagesController < ApplicationController
   end
 
   def create
+    binding.pry
     @message = @room.messages.new(message_params)
     if @message.save
       redirect_to room_messages_path(@room), notice: 'メッセージが送信されました'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.name @message.user.name
+json.text @message.text
+json.image @message.image.url
+json.time @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/rooms/_template_room.haml
+++ b/app/views/rooms/_template_room.haml
@@ -1,5 +1,5 @@
 - current_user.rooms.each do |room|
-  = link_to "/rooms/#{room.id}/messages" do 
+  = link_to room_messages_path(room) do
     .room-name
       = room.name
     .room-info

--- a/app/views/rooms/_template_room.haml
+++ b/app/views/rooms/_template_room.haml
@@ -1,9 +1,6 @@
-!!!
-%html
-  %body
-    - current_user.rooms.each do |room|
-      = link_to "/rooms/#{room.id}/messages" do 
-        .room-name
-          = room.name
-        .room-info
-          = room.show_last_message
+- current_user.rooms.each do |room|
+  = link_to "/rooms/#{room.id}/messages" do 
+    .room-name
+      = room.name
+    .room-info
+      = room.show_last_message


### PR DESCRIPTION
# What
メッセージの送信と描画を非同期通信を用いて行うようにする。
①メッセージの投稿をトリガーに、Ajaxでcreateアクションが起動するようにする。
②メッセージが保存された後、jbuilderによってメッセージの内容がJSONに変換される。
③受け取ったJSONをHTMLとして画面最下部に描画（この時画面は最下部までスクロールさせる）
④送信ボタンは同一セッションでなんども押下できるように設定
⑤非同期に失敗した場合にはエラーメッセージを表示

# Why
メッセージの送信・描画を非同期通信で実行することによって、ユーザはシームレスにチャットによるコミュニケーションを楽しむことができるようになる。
ブラウザが受信するデータ量も削減される。